### PR TITLE
Allow more recent versions of pyyaml than 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
         'yaml', 'block', 'flow', 'readable',
     ],
     install_requires=[
-        'PyYAML >= 3.11, <= 3.13',
+        'PyYAML >= 3.11',
     ],
 )


### PR DESCRIPTION
Allow more recent versions of pyyaml than 3.13.

Verified to work at least with PyYAML 5.3.1, which is the version currently in Debian unstable.
